### PR TITLE
Updated README adds instruction to NOT break ORCID integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ DOI Requests need some extra setup:
 1. Migrate: `rake db:migrate`
 1. Create an admin user: `rake datarepo:setup_roles`
 1. Install Orcid: `rails generate orcid:install --skip-application-yml`
+1. Revert changes already incorporated: `git checkout ./app/models/user.rb ./config/routes.rb`
 1. Run the CAS installation script: https://github.com/VTUL/InstallScripts/blob/master/Vagrant/CAS_extras.sh
   - The script takes two parameters, the name of the repository, and the name of the server
   - Example: `bash ./CAS_extras.sh data-repo myserver.com`

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   blacklight_for :catalog
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  mount Orcid::Engine => "/orcid"
   mount Hydra::RoleManagement::Engine => '/'
   resources :doi_requests, :only => [:index, :show, :create] do
     member do


### PR DESCRIPTION
Also adds a line to routes that was being added by the ORCID installer. However, the installer was causing more problems in config/routes.rb and app/models/user.rb than it helped.