### PR TITLE
Add rake task to automate adding users.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,3 +58,4 @@ gem 'orcid'
 gem 'ezid-client'
 gem "hydra-role-management"
 gem 'omniauth-cas'
+gem 'net-ldap'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -346,6 +346,7 @@ GEM
     nest (1.1.2)
       redis
     net-http-persistent (2.9.4)
+    net-ldap (0.11)
     noid (0.7.1)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -668,6 +669,7 @@ DEPENDENCIES
   jettywrapper
   jquery-rails
   kaminari!
+  net-ldap
   omniauth-cas
   orcid
   rails (~> 4.2.1)

--- a/lib/tasks/datarepo.rake
+++ b/lib/tasks/datarepo.rake
@@ -1,9 +1,10 @@
+require 'net/ldap'
+
 task :with_defaults, [:email, :password] do |t, defaults|
   defaults.with_defaults(:email => :default_email, :password => :default_password)
 end
 
-namespace :datarepo do 
-
+namespace :datarepo do
   desc 'Setup default roles and admin'
   task setup_defaults: :environment do
     desc 'Setup Roles'
@@ -13,7 +14,7 @@ namespace :datarepo do
 
     desc 'Set up a default Admin email and password'
     default_email = "admin@lib.vt.edu"
-    default_password = "datarepo_password" 
+    default_password = "datarepo_password"
     Rake::Task[:with_defaults].invoke(default_email, default_password)
     if User.find_by_email(default_email).nil?
       User.create(email: default_email, password: default_password, role_ids: [Role.where(name: 'admin').first.id])
@@ -22,6 +23,39 @@ namespace :datarepo do
       puts "Default admin email is: #{default_email}"
     end
   end
-  
+
+  desc 'Add initial users.'
+  task  populate_users: :environment do
+    ldap = Net::LDAP.new(host: 'directory.vt.edu')
+    treebase = 'ou=People,dc=vt,dc=edu'
+    ldap_attributes = {'uid': :authid, 'display_name': :displayname, 'department': :department, 'address': :postaladdress}
+
+    IO.foreach('emails.txt') do |email|
+      email = email.strip
+      filter = Net::LDAP::Filter.eq('mail', email)
+      results = ldap.search(base: treebase, filter: filter)
+      if results.count == 1
+        user = User.find_or_initialize_by({'email': email})
+        user.provider = 'cas'
+        user.uid = email.split('@')[0]
+        user.password = Devise.friendly_token
+
+        result = results[0]
+        ldap_attributes.each do |user_attr, ldap_attr|
+          user_attr = user_attr.to_sym
+          if result.respond_to?(ldap_attr)
+            user[user_attr] = result[ldap_attr][0]
+          end
+        end
+
+        user.save!
+        puts "Created '#{email}'"
+      elsif results.count > 1
+        puts "Searching for '#{email}' did not return a unique result."
+      else
+        puts "Searching for '#{email}' did not return any results."
+      end
+    end
+  end
 end
 


### PR DESCRIPTION
- Add net-ldap to Gemfile, ldap-properties to the user. (Requires bundle install after merge.)
- Allow the rake task to update existing users, by using User.find_or_initialize_by()
- The uid prefers to be set from ED-Lite, along with display_name, department, and address.