### PR TITLE
Configure e-mail settings in Data Repository application.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,8 @@
+Sufia::Engine.configure do
+ config.contact_email = 'root@localhost'
+ config.from_email = "no-reply@localhost"
+end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -13,6 +18,14 @@ Rails.application.configure do
   config.consider_all_requests_local       = true
   config.action_controller.perform_caching = false
 
+  # E-mail settings
+  config.action_mailer.delivery_method = :sendmail
+  # Defaults to:
+  # config.action_mailer.sendmail_settings = {
+  #   location: '/usr/sbin/sendmail',
+  #   arguments: '-i -t'
+  # }
+  config.action_mailer.perform_deliveries = false
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,8 @@
+Sufia::Engine.configure do
+ config.contact_email = 'root@localhost'
+ config.from_email = "no-reply@#{`cat /etc/mailname`}".chomp
+end
+
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
@@ -81,4 +86,14 @@ Rails.application.configure do
   config.to_prepare { Devise::SessionsController.force_ssl }
   config.to_prepare { Devise::RegistrationsController.force_ssl }
   config.to_prepare { Devise::PasswordsController.force_ssl }
+
+  # E-mail settings
+  config.action_mailer.delivery_method = :sendmail
+  # Defaults to:
+  # config.action_mailer.sendmail_settings = {
+  #   location: '/usr/sbin/sendmail',
+  #   arguments: '-i -t'
+  # }
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.raise_delivery_errors = true
 end


### PR DESCRIPTION
Configure Action Mailer to send e-mail in production but not in
development.  Action Mailer is set to use the sendmail transport.

We also set the address to send mail to in the Contact form and the
e-mail address the contact form appears to come from, too.

For now, root@localhost is being used as a placeholder address in
production.rb, until a permanent delivery address is obtained.

Note: the ContactForm configuration options were rather obscure to
discern.