### PR TITLE
Changed view of required message

### DIFF
--- a/app/views/generic_files/_descriptions.html.erb
+++ b/app/views/generic_files/_descriptions.html.erb
@@ -1,0 +1,18 @@
+<div id="descriptions_display" class="tab-pane active">
+  <%= simple_form_for [sufia, @form], html: { multipart: true } do |f| %>
+    <%= hidden_field_tag('redirect_tab', 'descriptions') %>
+      <h2 class="non lower">Descriptions <small class="pull-right"><span class="error">*</span> indicates required fields</small> </h2>
+	<div class="well">
+
+        <% f.object.terms.each do |term| %>
+          <%= render_edit_field_partial(term, f: f) %>
+        <% end %>
+
+      </div><!-- /well -->
+    <div>
+      <%= f.submit class: 'btn btn-primary', onclick: "confirmation_needed = false;", id: "upload_submit", name: "update_descriptions" do %>
+        <i class="glyphicon glyphicon-floppy-disk"></i> Save Descriptions
+      <% end %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
This is a bugfix for LIBTD-178: Edit generic file
page: "* indicates required fields" should not a
header
Copied app/views/generic_files/_descriptions.html.erb
from projecthydra/sufia to data-repo and modified
html to fix the view related bug