### PR TITLE
Change logging options for production and development environments.

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,4 +56,8 @@ Rails.application.configure do
   config.to_prepare { Devise::SessionsController.force_ssl }
   config.to_prepare { Devise::RegistrationsController.force_ssl }
   config.to_prepare { Devise::PasswordsController.force_ssl }
+
+  # Logging
+  config.logger = Logger.new(Rails.root.join('log', "#{Rails.env}.log"), "daily")
+  config.log_level = :debug
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,10 +49,6 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 
-  # Use the lowest log level to ensure availability of diagnostic information
-  # when problems arise.
-  config.log_level = :debug
-
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
 
@@ -96,4 +92,8 @@ Rails.application.configure do
   # }
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
+
+  # Logging
+  config.logger = Logger.new(Rails.root.join('log', "#{Rails.env}.log"), "daily")
+  config.log_level = :warn
 end


### PR DESCRIPTION
Change the default logger to one that rotates logs on a daily basis.
Also, we set the log level explicitly for each environment: "debug" for
development and "warn" for production.