### PR TITLE
Add migration for DOI table changes.

### DIFF
--- a/db/migrate/20150827213953_change_doi_request.rb
+++ b/db/migrate/20150827213953_change_doi_request.rb
@@ -1,0 +1,8 @@
+class ChangeDoiRequest < ActiveRecord::Migration
+  def change
+    remove_column :doi_requests, :completed
+    remove_index :doi_requests, column: :collection_id
+    rename_column :doi_requests, :collection_id, :asset_id
+    add_index :doi_requests, [:asset_id, :asset_type]
+  end
+end


### PR DESCRIPTION
Changes the collection_id column to asset_id, removes the completed
column, and replaces the index on the old collection_id column with an
index of asset_id and asset_type together.