### PR TITLE
Replace manual pattern checking with jquery validator

### DIFF
--- a/app/assets/javascripts/datarepo/funder.js
+++ b/app/assets/javascripts/datarepo/funder.js
@@ -12,25 +12,23 @@ Blacklight.onLoad(function() {
         $(funderClass)[index].value = newstring;
       }
   });
+$.validator.addMethod(
+	"datarepoFunder",
+	function(value, element, regexp) {
+	    var re = new RegExp(regexp);
+	    return this.optional(element) || re.test(value);
+	},
+	"Please enter correct funding Information format. (funder name: award number)"
+);
 
-  $('#create_submit, #update_submit').click(function( event ) {
-    $check = false;
-    $(funderClass).each( function(index, value) {
-      if ((value.value.indexOf(":") == -1) && value.value.length > 0) {
-        $check = true;
-      }
-    });
-
-    if ( $check && ( $( "p.fundermessage" ).text().length <=0 )  ) {
-      $( "<p style='color:red' class='fundermessage'>Please enter correct funding Information format. (funder name:award number)</p>" ).insertBefore( ".form-group.collection_funder" );
-      event.preventDefault();
-    } else if ($check) {
-      $( "p.fundermessage" ).show();
-      event.preventDefault();
-    } else {
-      $( "p.fundermessage" ).hide();
-      return;
-    }
-  });
+$(".simple_form").validate({
+	errorPlacement: function(error, element){		
+		if (element.parent().hasClass("input-group") )		
+			error.insertAfter( element.parent() );
+		else
+			error.insertAfter( element );
+	}
+});
+$(funderClass).rules("add", {datarepoFunder: ".*:.*"});
 
 });

--- a/app/views/records/edit_fields/_funder.html.erb
+++ b/app/views/records/edit_fields/_funder.html.erb
@@ -1,5 +1,6 @@
 <% if f.object.class.multiple? key %>
-  <%= f.input :funder, as: :multi_value_with_help, input_html: { class: 'form-control datarepo-funder', placeholder: 'funder name: award number'}, required: false %>
+  <%= f.input :funder, as: :multi_value_with_help, input_html: { class: 'form-control datarepo-funder', placeholder: 'funder name: award number'}, required: false, pattern: '.*:.*' %>
 <% else %>
-  <%= f.input :funder, input_html: { class: 'form-control datarepo-funder', placeholder: 'funder name: award number'} %>
+  <%= f.input :funder, input_html: { class: 'form-control datarepo-funder', placeholder: 'funder name: award number', pattern: '.*:.*' } %>
+<div class="errorTxt"></div>
 <% end %>


### PR DESCRIPTION
There is a option for pattern matching in HTML5, i have enabled that, no JS required any more
If some browser does not support HTML5, we can use jquery validator (it is already included). I have utilized it on the entire collection form