### PR TITLE
Set production e-mail address.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,5 @@
 Sufia::Engine.configure do
- config.contact_email = 'root@localhost'
+ config.contact_email = 'vtechdata@vt.edu'
  config.from_email = "no-reply@#{`cat /etc/mailname`}".chomp
 end
 


### PR DESCRIPTION
Use vtechdata@vt.edu for the contact address instead of forwarding from
root@localhost.