### PR TITLE
Add "pg" gem for PostgreSQL database adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,3 +60,4 @@ gem "hydra-role-management"
 gem 'omniauth-cas'
 gem 'net-ldap'
 gem 'jquery-ui-rails'
+gem "pg"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,6 +395,7 @@ GEM
     orm_adapter (0.5.0)
     parslet (1.7.1)
       blankslate (>= 2.0, <= 4.0)
+    pg (0.18.3)
     rack (1.6.4)
     rack-protection (1.5.3)
       rack
@@ -673,6 +674,7 @@ DEPENDENCIES
   net-ldap
   omniauth-cas
   orcid
+  pg
   rails (~> 4.2.1)
   rsolr (~> 1.0.6)
   rspec-rails


### PR DESCRIPTION
The Rails "postgresql" database adapter requires the "pg" gem to
implement access.