### PR TITLE
Backport improvements from ETDplus development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,16 @@
 *.rbc
 capybara-*.html
 .rspec
-/log
+
+# Ignore all logfiles and tempfiles.
+/log/*
+!/log/.keep
 /tmp
+
+# Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal
+
 /public/system
 /coverage/
 /spec/tmp


### PR DESCRIPTION
These changes are in tandem with the changes to the InstallScripts
repository that incorporate improvements from development on the
ETDplus project.

Because we are no longer doing a "rails new" during install, we must
ensure we have certain necessary directories.  The existing .gitignore
means we do not have a log directory when cloning the application code.
This causes rake tasks to fail because they can't log within their
RAILS_ENV environment.