### PR TITLE
Specify Google Analytics ID in secrets.yml

### DIFF
--- a/config/initializers/sufia.rb
+++ b/config/initializers/sufia.rb
@@ -80,7 +80,9 @@ Sufia.config do |config|
   config.analytics = false
 
   # Specify a Google Analytics tracking ID to gather usage statistics
-  # config.google_analytics_id = 'UA-99999999-1'
+  unless Rails.application.secrets['google_analytics_id'].nil?
+    config.google_analytics_id = Rails.application.secrets['google_analytics_id']
+  end
 
   # Specify a date you wish to start collecting Google Analytic statistics for.
   # config.analytic_start_date = DateTime.new(2014,9,10)


### PR DESCRIPTION
Like many other configuration settings, we now set the
config.google_analytics_id setting if there exists a
"google_analytics_id" setting in config/secrets.yml for the current
environment.

If a key is not set in config/secrets.yml, Rails.application.secrets
will return nil when attempting to reference that key.  By testing for
nil we attempt to mimic the original behaviour whereby
config.google_analytics_id defaults to being unset in the code.