### PR TITLE
Increase database.yml options

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -4,6 +4,8 @@ default: &default
   database: <%= Rails.application.secrets['database']['name'] %>
   username: <%= Rails.application.secrets['database']['username'] %>
   password: <%= Rails.application.secrets['database']['password'] %>
+  <%= "host: #{Rails.application.secrets['database']['host']}" unless Rails.application.secrets['database']['host'].nil? %>
+  <%= "port: #{Rails.application.secrets['database']['port']}" unless Rails.application.secrets['database']['port'].nil? %>
 
 development:
   <<: *default


### PR DESCRIPTION
Amend database.yml so that an optional "host" and "port" option may be
specified via config/secrets.yml.  This will allow the application to
point to a PostgreSQL database running on a different host.