### PR TITLE
Switch to VT Login SSO endpoints

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -42,7 +42,7 @@ en:
       updated: "Your account has been updated successfully."
     sessions:
       signed_in: "Signed in successfully."
-      signed_out: "You have been logged out of VTechData. To log out of all applications, <a href='https://auth.vt.edu/logout'>log out of Virginia Tech CAS.</a>"
+      signed_out: "You have been logged out of VTechData. To log out of all applications, <a href='https://login.vt.edu/profile/cas/logout'>log out of Virginia Tech CAS.</a>"
       already_signed_out: "Signed out successfully."
     unlocks:
       send_instructions: "You will receive an email with instructions for how to unlock your account in a few minutes."

--- a/config/secrets.yml.sample
+++ b/config/secrets.yml.sample
@@ -32,7 +32,10 @@ default: &default
   redis: &redis
     host: localhost # Hostname of Redis server
     port: 6379      # TCP/IP port of Redis server
-  cas_endpoint_url: https://cas-dev.middleware.vt.edu    # URL of CAS service endpoint
+  # URL of CAS service endpoint.  Use one of the following endpoints at Virginia Tech:
+  # Development: https://login-dev.middleware.vt.edu/profile/cas
+  # Production: https://login.vt.edu/profile/cas
+  cas_endpoint_url: https://login-dev.middleware.vt.edu/profile/cas
   # The google_analytics_id: below should only be defined if usage statistics
   # are to be gathered.  Leave commented otherwise.
 # google_analytics_id: UA-99999999-1                     # Google Analytics tracking ID


### PR DESCRIPTION
Use the new VT Login SSO service instead of the old CAS service, which
will be retiring in the near future.