### PR TITLE
Fix creator and contributor fields.

### DIFF
--- a/app/views/batch/_metadata.html.erb
+++ b/app/views/batch/_metadata.html.erb
@@ -32,7 +32,7 @@
 
       <%= f.input :tag, as: :multi_value_with_help %>
 
-      <%= f.input :creator, as: :multi_value_with_help, input_html: { class: 'datarepo-autocomplete' } %>
+      <%= f.input :creator, as: :multi_value_with_help  %>
 
       <%= f.input :rights, as: :select_with_modal_help, collection: Sufia.config.cc_licenses,
           input_html: { class: 'form-control', multiple: true } %>

--- a/app/views/records/edit_fields/_contributor.html.erb
+++ b/app/views/records/edit_fields/_contributor.html.erb
@@ -1,4 +1,4 @@
-<%= f.input key, as: :multi_value, input_html: { class: 'form-control datarepo-autocomplete' }, required: f.object.required?(key) %>
+<%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
 <input class="ldap-txt contributor" id="ldap-txt-contributor">
 <input class="ldap-search contributor" type="button" id="ldap-search-contributor" value="search people">
 <div class="ldap-results contributor"></div>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,4 +1,4 @@
-<%= f.input key, as: :multi_value, input_html: { class: 'form-control datarepo-autocomplete' }, required: f.object.required?(key) %>
+<%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
 <input class="ldap-txt creator" id="ldap-txt-creator">
 <input class="ldap-search creator" type="button" id="ldap-search-creator" value="search people">
 <div class="ldap-results creator"></div>


### PR DESCRIPTION
Remove "datarepo-autocomplete" class from creator and contributor fields to restore functionality until the autocomplete JS can be fixed.

<img width="1414" alt="screen shot 2016-07-15 at 1 44 24 pm" src="https://cloud.githubusercontent.com/assets/1202435/16883575/ab8a931c-4a92-11e6-9033-3520033f77fe.png">
