### PR TITLE
Add additional settings to define which ORCiD service is used

### DIFF
--- a/config/application.yml
+++ b/config/application.yml
@@ -9,3 +9,7 @@
 # From http://support.orcid.org/knowledgebase/articles/162412-tutorial-create-a-new-profile-using-curl
 ORCID_APP_ID: <%= Rails.application.secrets['orcid']['app_id'] %>
 ORCID_APP_SECRET: <%= Rails.application.secrets['orcid']['app_secret'] %>
+ORCID_SITE_URL: <%= Rails.application.secrets['orcid']['site_url'] %>
+ORCID_TOKEN_URL: <%= Rails.application.secrets['orcid']['token_url'] %>
+ORCID_REMOTE_SIGNIN_URL: <%= Rails.application.secrets['orcid']['remote_signin_url'] %>
+ORCID_AUTHORIZE_URL: <%= Rails.application.secrets['orcid']['authorize_url'] %>

--- a/config/secrets.yml.sample
+++ b/config/secrets.yml.sample
@@ -29,6 +29,10 @@ default: &default
   orcid: &orcid
     app_id: 0000-0000-0000-0000                          # ORCID client ID
     app_secret: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX     # ORCID client secret
+    site_url: http://api.sandbox.orcid.org
+    token_url: https://api.sandbox.orcid.org/oauth/token
+    remote_signin_url: https://sandbox.orcid.org/signin/auth.json
+    authorize_url: https://sandbox.orcid.org/oauth/authorize
   redis: &redis
     host: localhost # Hostname of Redis server
     port: 6379      # TCP/IP port of Redis server


### PR DESCRIPTION
The ORCiD service has available a sandbox and production service.  The
one used is determined by various URLs assigned to ORCID_*_URL
environment variables, which define API endpoints.  If these
environment variables are unset then they default to the ones used by
the sandbox service.

This change extends the settings that may be assigned in
config/application.yml.  The "orcid" gem uses this file to set
ORCiD-related environment variables.  We, in turn, derive the actual
value set from the "orcid" key in config/secrets.yml.

This will allow the application to use the sandbox or production ORCiD
service.