### PR TITLE
Adds Xray

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
+  gem 'xray-rails'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -710,6 +710,8 @@ GEM
     xml-simple (1.1.5)
     xpath (2.0.0)
       nokogiri (~> 1.3)
+    xray-rails (0.2.0)
+      rails (>= 3.1.0)
     yaml_db (0.4.0)
       rails (>= 3.0, < 5.1)
       rake (>= 0.8.7)
@@ -757,6 +759,7 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+  xray-rails
 
 BUNDLED WITH
    1.13.6


### PR DESCRIPTION
Xray allows developers to see which partial rendered each part of a displayed page. Added to development environments only.

![Xray in action](https://cloud.githubusercontent.com/assets/638392/19772735/1f29ae22-9c35-11e6-9e01-772b41f87f88.png)
