### PR TITLE
Log to Graylog server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,3 +72,5 @@ gem "hydra-role-management"
 gem 'omniauth-cas'
 gem 'net-ldap'
 gem 'jquery-ui-rails'
+gem 'gelf'
+gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,8 @@ GEM
       railties (>= 3.2, < 5.1)
     foreigner (1.7.4)
       activerecord (>= 3.0.0)
+    gelf (3.0.0)
+      json
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     google-api-client (0.8.6)
@@ -345,6 +347,10 @@ GEM
     logging (2.1.0)
       little-plugger (~> 1.1)
       multi_json (~> 1.10)
+    lograge (0.4.1)
+      actionpack (>= 4, < 5.1)
+      activesupport (>= 4, < 5.1)
+      railties (>= 4, < 5.1)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.4)
@@ -722,12 +728,14 @@ DEPENDENCIES
   devise-guests (~> 0.3)
   ezid-client
   factory_girl_rails
+  gelf
   hydra-role-management
   jbuilder (~> 2.0)
   jettywrapper
   jquery-rails
   jquery-ui-rails
   kaminari!
+  lograge
   net-ldap
   omniauth-cas
   orcid
@@ -751,4 +759,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.12.5
+   1.13.6


### PR DESCRIPTION
Change production logging to log to a Graylog server GELF input. The
Graylog server settings are specified in config/secrets.yml under a
"graylog" key. The "enabled" key under "graylog" must be set to "true"
to enable Graylog logging, otherwise the default Rails logger is used.
The Ansible InstallScripts set an appropriate default.

We only enable Graylog logging for RAILS_ENV="production" mode by
adding the code to set it up to config/environments/production.rb.

We use the "gelf" and "lograge" gems to do the logging. This is per
the Graylog documentation on how to ingest Rails logs into Graylog.
Note that the "lograge" gem produces much more concise logging than
the standard Rails logger.