### PR TITLE
Adds arrows to dashboard heading when larger than mobile

### DIFF
--- a/app/assets/stylesheets/dashboard.scss
+++ b/app/assets/stylesheets/dashboard.scss
@@ -1,5 +1,7 @@
 @import 'global';
 
+$arrow-width: 80px;
+
 div.dashboard-breadcrumb {
   margin-bottom: 20px;
   margin-top: 20px;
@@ -39,6 +41,31 @@ div.heading-tile a:hover {
   text-decoration: none;
 }
 
+div.arrow-wrapper {
+  width: $arrow-width;
+  height: 116px;
+  svg {
+    position: relative;
+    display: block;
+    width: 100%;
+    height: 50px;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+  .arrow {
+    fill: $hokie-orange;
+  }
+}
+@media screen and (max-width: 767px) {
+  div.arrow-wrapper {
+    display: none;
+  }
+}
+@media screen and (min-width: 768px) {
+  div.heading-tile {
+    width: calc(25% - (#{$arrow-width} * .75));
+  }
+}
 
 .dashboard {
   .panel-default > .panel-heading {

--- a/app/views/dashboard/_index_partials/_heading_actions.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_actions.html.erb
@@ -7,6 +7,7 @@
           <%= t("sufia.dashboard.upload") %>
       <% end %>
     </div>
+    <%= render partial: "dashboard/_index_partials/heading_arrow" %>
   <% end %>
   <div class="col-xs-6 col-sm-3 heading-tile <%="active" if current_dashboard_tab?(:describe) %>">
     <%= link_to sufia.dashboard_files_path  do %>
@@ -14,6 +15,7 @@
         <%= t("sufia.dashboard.view_files") %>
     <% end %>
   </div>
+  <%= render partial: "dashboard/_index_partials/heading_arrow" %>
   <% if can?(:create, Collection) %>
     <div class="col-xs-6 col-sm-3 heading-tile <%="active" if current_dashboard_tab?(:organize) %>">
       <%= link_to sufia.dashboard_collections_path, id: "hydra-collection-add" do %>
@@ -21,6 +23,7 @@
           <%= t("sufia.dashboard.create_collection") %>
       <% end %>
     </div>
+    <%= render partial: "dashboard/_index_partials/heading_arrow" %>
   <% end  %>
   <div class="col-xs-6 col-sm-3 heading-tile <%="active" if current_dashboard_tab?(:publish) %>">
     <%= link_to dashboard_publishables_path, id: "hydra-collection-view" do %>

--- a/app/views/dashboard/_index_partials/_heading_arrow.html.erb
+++ b/app/views/dashboard/_index_partials/_heading_arrow.html.erb
@@ -1,0 +1,6 @@
+<div class="col-xs-6 col-sm-3 arrow-wrapper">
+  <svg viewBox="0 0 100 100" preserveAspectRatio="none" >
+    <rect class="arrow rectangle" x="0" y="32.5%" width="71%" height="35%" />
+    <polygon class="arrow triangle" points="70,0 100,50 70,100" />
+  </svg>
+</div>


### PR DESCRIPTION
add last arrow to partial. move arrow width into sass variable and do math based on that.

Apparently Mozilla can't read svg attributes from css? This is why we can't have nice things.
