### PR TITLE
Creates admins' user accounts if they do not exist.

### DIFF
--- a/lib/tasks/datarepo.rake
+++ b/lib/tasks/datarepo.rake
@@ -57,15 +57,15 @@ namespace :datarepo do
       email = email.strip
       user = User.find_by({email: email})
 
-      if !user.nil?
-        user.roles << admin_role
-        user.roles = user.roles.uniq
-        user.group_list = 'admin'
-        user.save!
-        puts "#{email} upgraded."
-      else
-        puts "Could not find a user with email address '#{email}'."
+      if user.nil?
+        user = User.new(email: email, uid: email, provider: 'cas')
       end
+
+      user.roles << admin_role
+      user.roles = user.roles.uniq
+      user.group_list = 'admin'
+      user.save!
+      puts "#{email} upgraded."
     end
   end
 


### PR DESCRIPTION
This fixes an issue where people who do not have LDAP records associated with the correct email could not be admins.
