### PR TITLE
Ignore public/assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ capybara-*.html
 /db/*.sqlite3-journal
 
 /public/system
+/public/assets
 /coverage/
 /spec/tmp
 **.orig


### PR DESCRIPTION
Is there a reason for tracking the public/assets directory? It seems like it should be safe to ignore since the assets are compiled during the deployment process. If there is a reason that I'm overlooking please feel free to close this pull request.