### PR TITLE
Pin uglifier Gem to pre 4.x version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'sprockets', '~> 3.3.4'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 # Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
+gem 'uglifier', '>= 1.3.0', '< 4'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -700,7 +700,7 @@ GEM
     turbolinks-source (5.0.3)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
-    uglifier (4.0.2)
+    uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
     vegas (0.1.11)
       rack (>= 1.0.0)
@@ -770,9 +770,9 @@ DEPENDENCIES
   sqlite3
   sufia (= 6.6.1)
   turbolinks
-  uglifier (>= 1.3.0)
+  uglifier (>= 1.3.0, < 4)
   web-console (~> 2.0)
   xray-rails
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Support for the "copyright" option was dropped in v4.0.0 of the uglifier Gem.  Thus, we pin to a pre-4.x version to allow uglifier to work with our code.