### PR TITLE
fix notifications, pull jquery-rails back to 5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,11 +301,11 @@ GEM
       i18n
       logger
       rubyzip (~> 1.0)
-    jquery-rails (4.3.1)
+    jquery-rails (4.1.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    jquery-ui-rails (6.0.1)
+    jquery-ui-rails (5.0.5)
       railties (>= 3.2.16)
     json (1.8.6)
     json-ld (1.99.2)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,6 @@
 class UsersController < ApplicationController
   include Sufia::UsersControllerBehavior
-  prepend_before_action :find_user, except: [:depositor_list_export]
+  prepend_before_action :find_user, except: [:index, :search, :notifications_number, :depositor_list_export]
   before_action :authenticate_user!
   before_action :require_admin, only: [:depositor_list_export]
   before_action :admin_and_user_only, only: [:show]


### PR DESCRIPTION
Updated version of jquery rails was causing errors on the Item new/edit form. You can see it on data.pprd.lib.vt.edu. Had to pin it back to 5.

Also, find user shouldn't be run on a few pages. Those errors can also be seen on pprd.