### PR TITLE
add delete links for admins

### DIFF
--- a/app/views/collections/_show_actions.html.erb
+++ b/app/views/collections/_show_actions.html.erb
@@ -8,15 +8,22 @@
         <%= link_to  collections_add_files_path(@collection), class: "btn btn-default", title: "Edit this Dataset" do %>
           <span class="glyphicon glyphicon-file"></span> Files
         <% end %>
-        <div>The maximum export dataset file size is limited to 3GB.</div>
         <% if @can_export %>
-          <%= link_to collections_download_path(@collection), class: "btn btn-default", title: "Export this Dataset" do %>
+          <%= link_to collections_download_path(@collection), id: "dataset_export_button", collection_id: @collection.id , class: "btn btn-default", title: "Export this Dataset" do %>
             <span class="glyphicon glyphicon-download"></span> Export dataset
           <% end %>
         <% else %>
           <div style="clear:both">The size of this dataset is too large to export or is unknown.</div>
         <% end %>
       </div>
+      <div style="clear:both">The maximum export dataset file size is limited to 3GB.</div>
+    <% end %>
+    <% if can? :delete, @collection %>
+      <p>
+      <%= link_to raw('<i class="glyphicon glyphicon-trash" aria-hidden="true"></i> Delete Dataset'), collections.collection_path(@collection.id),
+     class: 'btn btn-default itemicon itemtrash', title: 'Delete Dataset', method: :delete, data: {
+     confirm: "Deleting a dataset from #{t('sufia.product_name')} is permanent. Click OK to delete this dataset from #{t('sufia.product_name')}, or Cancel to cancel this operation" } %>
+      </p>
     <% end %>
 </div>
 

--- a/app/views/generic_files/_show_actions.html.erb
+++ b/app/views/generic_files/_show_actions.html.erb
@@ -1,0 +1,58 @@
+<div id="show_actions">
+<h2 class="non lower">Actions</h2>
+    <p>
+      <%= render_download_link %>
+      <% if Sufia.config.analytics %>
+        &nbsp;|&nbsp;
+        <%= link_to "Analytics", sufia.stats_generic_file_path(@generic_file), id: 'stats' %>
+      <% end %>
+      <% if Sufia.config.citations %>
+        &nbsp;|&nbsp;
+        <%= link_to "Citations", sufia.citation_generic_file_path(@generic_file), id: 'citations' %>
+      <% end %>
+      <% if can? :edit, @generic_file %>
+          &nbsp;|&nbsp;
+          <% if @generic_file.processing? %>
+            <%= t('sufia.upload.processing') %>
+          <% else %>
+            <%= link_to "Edit", sufia.edit_generic_file_path(@generic_file) %>
+          <% end %>
+      <% end %>
+      <% if can?(:create, FeaturedWork) && @generic_file.public? %>
+        <% if FeaturedWork.can_create_another? && !@generic_file.featured?%>
+          &nbsp;|&nbsp;
+          <%= link_to "Feature", sufia.featured_work_path(@generic_file, format: :json), data: {behavior: 'feature'} %>
+        <% elsif @generic_file.featured? %>
+          &nbsp;|&nbsp;
+          <%= link_to "Unfeature", sufia.featured_work_path(@generic_file, format: :json), data: {behavior: 'unfeature-page'} %>
+        <% end %>
+      <% end %>
+    </p>
+    <p>
+      <% if can? :delete, @generic_file %>
+        <%= link_to raw('<i class="glyphicon glyphicon-trash" aria-hidden="true"></i> Delete File'), sufia.generic_file_path(@generic_file.id),
+      class: 'itemicon itemtrash', title: 'Delete File', method: :delete, data: {
+      confirm: "Deleting a file from #{t('sufia.product_name')} is permanent. Click OK to delete this file from #{t('sufia.product_name')}, or Cancel to cancel this operation" } %>
+      <% end %>
+    </p>
+    <p>Export to:
+      <%= link_to 'EndNote', sufia.generic_file_path(@generic_file, format: 'endnote') %>
+      &nbsp;|&nbsp;
+      <%= link_to 'Zotero', sufia.static_path('zotero'), {id: 'zoteroLink', name: 'zotero', class: 'lightboxLink'} %>
+      &nbsp;|&nbsp;
+      <%= link_to 'Mendeley', sufia.static_path('mendeley'), {id: 'mendeleyLink', name: 'mendeley', class: 'lightboxLink'} %>
+    </p>
+    <!-- AddThis Button BEGIN -->
+    <div class="addthis_toolbox addthis_default_style">
+      <a class="addthis_button_preferred_1"></a>
+      <a class="addthis_button_preferred_2"></a>
+      <a class="addthis_button_preferred_3"></a>
+      <a class="addthis_button_preferred_4"></a>
+      <a class="addthis_button_compact"></a>
+      <a class="addthis_counter addthis_bubble_style"></a>
+    </div>
+    <!-- AddThis Button END -->
+
+    <!-- COinS hook for Zotero -->
+    <span class="Z3988" title="<%= @generic_file.export_as_openurl_ctx_kev %>"></span>
+</div>


### PR DESCRIPTION
**Allow admins to delete datasets and items.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1349) (:star:)

# What does this Pull Request do? (:star:)
Adds delete link to show pages for items and datasets. Only rendered for users with delete privileges.

# What's the changes? (:star:)
Adds delete link to show pages for items and datasets. Only rendered for users with delete privileges.

# How should this be tested?
* Create items and datasets with a non-admin account
* Check to make sure that the delete link shows up in left column on the show pages
* Log out and check to make sure that the delete links do NOT show up
* Log in with an admin account and make sure that the delete links show up
* I guess make sure that the delete links actually work too

# Additional Notes:
* branch: `admin_delete`



# Interested parties
@shabububu 

(:star:) Required fields
