### PR TITLE
restrict edit identifier and publisher for datasets

### DIFF
--- a/app/presenters/datarepo_generic_file_presenter.rb
+++ b/app/presenters/datarepo_generic_file_presenter.rb
@@ -1,4 +1,4 @@
 class DatarepoGenericFilePresenter < Sufia::GenericFilePresenter
   self.terms += [:provenance]
-  self.terms -= [:publisher]
+  self.terms -= [:publisher, :identifier]
 end

--- a/app/views/records/edit_fields/_identifier.html.erb
+++ b/app/views/records/edit_fields/_identifier.html.erb
@@ -1,0 +1,7 @@
+<% if current_user.admin? && controller_name != "generic_files" %>
+  <% if f.object.class.multiple? key %>
+    <%= f.input key, as: :multi_value_with_help, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+  <% else %>
+    <%= f.input key, required: f.object.required?(key) %>
+  <% end %>
+<% end %>

--- a/app/views/records/edit_fields/_publisher.html.erb
+++ b/app/views/records/edit_fields/_publisher.html.erb
@@ -1,0 +1,7 @@
+<% if current_user.admin? %>
+  <% if f.object.class.multiple? key %>
+    <%= f.input key, as: :multi_value_with_help, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+  <% else %>
+    <%= f.input key, required: f.object.required?(key) %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
**Remove the ability of non-admins to edit the identifier and publisher fields for datasets**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1389) (:star:)

# What does this Pull Request do? (:star:)
Don't show the edit fields for identifier and publisher for non-admin users on the collection edit form.
Don't show identifier field for generic_files to anybody.

# What's the changes? (:star:)
Don't show the edit fields for identifier and publisher for non-admin users on the collection edit form.
Don't show identifier field for generic_files to anybody.

# How should this be tested?
* Log-in as a non-admin user
* Create a dataset (collection)
* Go to the collection edit page and check that the identifier and publisher fields do NOT render
* Give yourself admin privileges
* Go to the collection edit page and check that the identifier and publisher fields DO render
* Create an item (generic_file)
* Go to edit page and make sure that identifier field does NOT render

# Additional Notes:
* branch: `restrict_identifier_publisher`

# Interested parties
@shabububu 

(:star:) Required fields
