### PR TITLE
only show the doi radio buttons for new collections if user is admin

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -32,6 +32,11 @@ class CollectionsController < ApplicationController
     @citation = build_citation @collection
   end
 
+  def new
+    super
+    flash[:notice] = nil
+  end
+
   def after_create
       respond_to do |format|
         ActiveFedora::SolrService.instance.conn.commit

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -3,17 +3,18 @@
 </div>
 
 <h1>Create New Dataset</h1>
-
-<%= radio_button_tag :doi_status, "assigned", checked = false %>
-<%= label_tag(:doi_assigned, "This data set already has a DOI") %>
-<%= radio_button_tag :doi_status, "unassigned", checked = false %>
-<%= label_tag(:doi_not_assigned, "This dataset does not already have a DOI") %>
-<div id="datacite_search_form" style="display:none;">
-  <%= render 'datacite_search' %>
-</div>
-<div id="datacite_search_result" style="display:none;">
-  <%= render 'datacite_search_result' %>  
-</div>
-<div id="new_form_area" style="display:none;">
+<% if current_user.admin? %>
+  <%= radio_button_tag :doi_status, "assigned", checked = false %>
+  <%= label_tag(:doi_assigned, "This data set already has a DOI") %>
+  <%= radio_button_tag :doi_status, "unassigned", checked = false %>
+  <%= label_tag(:doi_not_assigned, "This dataset does not already have a DOI") %>
+  <div id="datacite_search_form" style="display:none;">
+    <%= render 'datacite_search' %>
+  </div>
+  <div id="datacite_search_result" style="display:none;">
+    <%= render 'datacite_search_result' %>  
+  </div>
+<% end %>
+<div id="new_form_area" style="<%= "display:none;" if current_user.admin? %>">
   <%= render 'form' %>
 </div>


### PR DESCRIPTION
**Don't allow non-admins to create datasets with pre-existing doi's.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1390) (:star:)

# What does this Pull Request do? (:star:)
Hides the radio buttons that allow users to choose "already has doi" or doesn't have a doi" when creating a new dataset (collection) for non-admin users

# What's the changes? (:star:)
* Hides the radio buttons that allow users to choose "already has doi" or doesn't have a doi" when creating a new dataset (collection) for non-admin users
* Also removes the "Select something first" flash message because it doesn't make any sense

# How should this be tested?
* Login as an admin user.
* Create a dataset
* Make sure that the radio box choices show up at the top of the collection#new page and that everything works as it should.
* Repeat the process as non-admin and make sure the radio-boxes do NOT show up and that it goes straight to the form.

# Additional Notes:
* branch: `no_preexisting_dois`

# Interested parties
@tingtingjh 

(:star:) Required fields
