### PR TITLE
Use forked version of resque gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,6 @@ gem 'jquery-ui-rails', '~> 5.0.5'
 gem 'gelf'
 gem 'lograge'
 gem 'archive'
+
+# Workarounds
+gem 'resque', git: 'https://github.com/VTUL/resque.git', branch: 'eager_load_fix'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,16 @@
 GIT
+  remote: https://github.com/VTUL/resque.git
+  revision: 07dcef797c4206c17ec4377dda4f9c3a8693aa0c
+  branch: eager_load_fix
+  specs:
+    resque (1.27.4)
+      mono_logger (~> 1.0)
+      multi_json (~> 1.0)
+      redis-namespace (~> 1.3)
+      sinatra (>= 0.9.2)
+      vegas (~> 0.1.2)
+
+GIT
   remote: https://github.com/jcoyne/kaminari.git
   revision: 7f7108e12bdd64eb5a76177633768feb14df5453
   branch: sufia
@@ -541,12 +553,6 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
-    resque (1.27.4)
-      mono_logger (~> 1.0)
-      multi_json (~> 1.0)
-      redis-namespace (~> 1.3)
-      sinatra (>= 0.9.2)
-      vegas (~> 0.1.2)
     resque-pool (0.6.0)
       rake
       resque (~> 1.22)
@@ -761,6 +767,7 @@ DEPENDENCIES
   poltergeist
   rails (= 4.2.6)
   rails-helper
+  resque!
   rsolr (~> 1.0.6)
   rspec-rails
   sass-rails (~> 5.0)
@@ -777,4 +784,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.2
+   1.16.5


### PR DESCRIPTION
**Use forked version of resque gem**
* * *

# What does this Pull Request do?

The `resque-pool` service currently fails to start up except in the Rails `production` environment.  This is due to a failure of the `resque` gem to initialise due to a "Cannot define multiple 'included' blocks for a Concern" error.  This problem was fixed in the `resque` gem in pull request 1597 (resque/resque#1597), but has not been incorporated into an official gem release yet.

This change alters the application `Gemfile` to depend upon a [forked version](https://github.com/VTUL/resque) of the last "1.x" release of the `resque` gem that incorporates the cherry-picked fix for the aforementioned problem.

Also included is the `Gemfile.lock` resulting from a `bundle install` resulting from the new `Gemfile` dependencies.

# What's the changes?

* New `Gemfile` using forked `resque` gem that fixes startup error;
* `Gemfile.lock` resulting from `bundle install` of new dependencies.

# How should this be tested?

* Deploy `data-repo` application in local Vagrant environment using InstallScripts;
* Enter resultant VM via `vagrant ssh`;
* Check that `resque-pool` service is running, e.g., via `ps agx | grep resque`.

# Additional Notes:

* Be sure to test deployment in both `development` and `production` environments.

# Interested parties
@tingtingjh @shabububu 