### PR TITLE
remove tmp from the export path url

### DIFF
--- a/app/views/metadata_export_mailer/notification_email.html.erb
+++ b/app/views/metadata_export_mailer/notification_email.html.erb
@@ -6,7 +6,7 @@
   <body>
     <h3>Hi <%= @user.name %>,</h3>
     <p>
-      Your metadata export has completed and is available at <%= File.join(@base_path, 'tmp', 'exports',  @download_id) %>
+      Your metadata export has completed and is available at <%= File.join(@base_path, 'exports',  @download_id) %>
     </p>
     <p>Thanks and have a great day!</p>
   </body>

--- a/app/views/metadata_export_mailer/notification_email.text.erb
+++ b/app/views/metadata_export_mailer/notification_email.text.erb
@@ -1,6 +1,6 @@
 Hi <%= @user.name %>,
 ===============================================
  
-Your metadata export has completed and is available at <%= File.join(@base_path, 'tmp', 'exports',  @download_id) %> 
+Your metadata export has completed and is available at <%= File.join(@base_path, 'exports',  @download_id) %> 
 
 Thanks and have a great day!


### PR DESCRIPTION
**Remove tmp from the url that is emailed to users.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1582) (:star:)

# What does this Pull Request do? (:star:)
Remove tmp from the url that is emailed to users.

# What's the changes? (:star:)
The email that is send to admins when they request a metadata export should look like this:
`https://data.lib.vt.edu/exports/103c70de86a750a04da87b2ad32ca63f`
NOT like this:
`https://data.lib.vt.edu/tmp/exports/103c70de86a750a04da87b2ad32ca63f`

# How should this be tested?
* Log in as an admin
* On the dashboard page click the `User Analytics Export` button
* To see the actual email you'll have to use a gem like 'mailcatcher' or something. Or maybe just write the email out to a string or something? Honestly, I'm not really sure how to test emails. It's really just removing 'tmp' from a string though.

# Additional Notes:
* branch: `export_email_fix`

# Interested parties
@tingtingjh 

(:star:) Required fields
