### PR TITLE
Trigger Ansible Tower deploy for "pprd" branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,11 @@ before_script:
   - RAILS_ENV=test bundle exec rake jetty:clean
   - RAILS_ENV=test bundle exec rake sufia:jetty:config
   - RAILS_ENV=test bundle exec rake jetty:start
+deploy:
+  provider: script
+  script: curl -fsSL -X POST -o /dev/null -u $AWX_USER:$AWX_PASS $AWX_TEMPLATE_URL
+  on:
+    branch: pprd
 addons:
   apt:
     packages:


### PR DESCRIPTION
**Trigger Ansible Tower deploy for "pprd" branch**
* * *

# What does this Pull Request do?

Add a "deploy" stage to the Travis CI build that triggers a launch of the Ansible Tower template associated with the `pprd` branch when merges are made to `pprd`. This requires that three secrets be set up as environment variables in the Travis settings for this repository:

* `AWX_USER`: Ansible Tower user
* `AWX_PASS`: password for above user
* `AWX_TEMPLATE_URL`: Ansible Tower endpoint URL to launch the appropriate template for this deploy.

The Ansible Tower user and template should already exist in the Ansible Tower setup that is being used to deploy the template. Also, permissions and access should be set appropriately so the template is able to be launched from Travis.

Note that the `deploy` stage will be skipped if the earlier build fails, i.e., in our case, if the tests run has failures.

# What's the changes?

Added a `deploy` section to the `.travis.yml` file that is set to run `on: branch: pprd`. If the `deploy` is triggered by a successful earlier build (i.e., the tests all pass) and the branch being operated on is `pprd` then it initiates an Ansible Tower deployment via a `POST` Curl request to the appropriate API endpoint URL.

# How should this be tested?

Currently, testing is somewhat moot because the tests do not pass and hence the `deploy` stage will always be skipped right now.

# Additional Notes:

These changes have been tested in the `pmather/data-repo` fork by nullifying the actual test runs in the `.travis.yml` file (i.e., so the `deploy` stage will always run, if the `branch` condition succeeds). This change was able to initiate a deployment of the "VTechData PPRD Deploy" Ansible Tower template for only the `pprd` branch. (All other branches just went through the normal build/test cycle only.)

# Interested parties
@soumikgh @zoto724 
