### PR TITLE
store dataset citation as metadata

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -29,7 +29,6 @@ class CollectionsController < ApplicationController
       end
     end
     @can_export = (@can_export && @dataset_size <= max_dataset_for_export)
-    @citation = build_citation @collection
   end
 
   def new
@@ -179,45 +178,11 @@ class CollectionsController < ApplicationController
     send_file zip_file, filename: filename
   end
 
-  def build_citation collection
-    return nil unless (!collection.identifier.blank? && collection.identifier.first.include?("doi:"))
-    datacite_api_base = "https://api.datacite.org/works/"
-    datacite_id = collection.identifier.first.gsub("doi:", "")
-    datacite_api_url = URI.parse(URI.encode(File.join(datacite_api_base, datacite_id).strip))
-    begin
-      response = HTTParty.get(datacite_api_url)   
-      datacite_record = JSON.parse(response.body)
-    rescue
-      logger.error "Error fetching datacite record for collection"
-    end
-    return nil unless response['errors'].nil? && !datacite_record.nil?
-
-    begin
-      datacite_attributes = datacite_record['data']['attributes']
-      creators = datacite_attributes['author'].map{ |author| format_name(author['literal']) }.join(", ")
-      date_published = "(#{datacite_attributes['published']})."
-      title = "#{datacite_attributes['title']} [Data set]."
-      publisher = "University Libraries, Virginia Tech"
-      doi = datacite_attributes['identifier']
-    rescue
-      puts "error generating citation"
-    end
-    if creators && date_published && title && publisher && doi
-      citation = "#{creators} #{date_published} #{title} #{publisher} #{doi}"
-    end
-    return citation
+  def collection_params
+    form_class.model_attributes(
+      params.require(:collection).permit(:title, :description, :citation, :members, part_of: [], contributor: [], creator: [], publisher: [], date_created: [], subject: [], language: [], rights: [], resource_type: [], identifier: [], based_near: [], tag: [], related_url: [])
+    )
   end
 
-  def format_name name
-    begin
-      creator_array = name.split(" ")
-      last = creator_array.last
-      rest_array = creator_array - [last]
-      creator = "#{last} #{rest_array.map{|name| name[0]}.join(" ")}"
-    rescue
-      puts "error formatting name"
-    end
-    creator || ""
-  end
 end
 

--- a/app/forms/my_collection_edit_form.rb
+++ b/app/forms/my_collection_edit_form.rb
@@ -2,5 +2,7 @@ class MyCollectionEditForm < MyCollectionPresenter
   include HydraEditor::Form
   include HydraEditor::Form::Permissions
 
+  self.terms += [:citation]  
+
   self.required_fields = [:title]
 end

--- a/app/forms/my_collection_edit_form.rb
+++ b/app/forms/my_collection_edit_form.rb
@@ -2,7 +2,5 @@ class MyCollectionEditForm < MyCollectionPresenter
   include HydraEditor::Form
   include HydraEditor::Form::Permissions
 
-  self.terms += [:citation]  
-
   self.required_fields = [:title]
 end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -4,4 +4,8 @@ class Collection < Sufia::Collection
     index.as :stored_searchable, :facetable
   end
 
+  property :citation, predicate: ::RDF::DC.bibliographicCitation, multiple: false do |index|
+    index.as :stored_searchable
+  end
+
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -26,4 +26,8 @@ class SolrDocument
   def provenance
     Array(self[Solrizer.solr_name("provenance")])
   end
+
+  def citation
+   Array(self[Solrizer.solr_name("citation")])
+  end
 end

--- a/app/presenters/my_collection_presenter.rb
+++ b/app/presenters/my_collection_presenter.rb
@@ -1,5 +1,5 @@
 class MyCollectionPresenter < Sufia::CollectionPresenter
-  self.terms = [:resource_type, :title, :creator, :contributor, :description,
+  self.terms = [:resource_type, :title, :creator, :contributor, :description, :citation,
                 :tag, :rights, :publisher, :date_created, :subject, :language,
                 :identifier, :based_near, :related_url, :funder]
 end

--- a/app/views/collections/_show_descriptions.html.erb
+++ b/app/views/collections/_show_descriptions.html.erb
@@ -1,0 +1,7 @@
+<h2 class="sr-only">Descriptions</h2>
+<dl class="dl-horizontal metadata-collections">
+  <% present_terms(@presenter, @presenter.terms_with_values - [:title, :description, :citation]) do |r, term| %>
+      <dt><%= r.label(term) %></dt>
+      <dd><%= r.value(term) %></dd>
+  <% end %>
+</dl>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -14,8 +14,8 @@
         <h1><%= @presenter.title %></h1>
         <p class="collection_description"><%= @presenter.description %></p>
       </header>
-      <% if !@presenter.citation.nil? %>
-      <p><b>Citation:</b> <%= @presenter.citation %>
+      <% if !@presenter.citation.blank? %>
+        <p><b>Citation:</b> <%= @presenter.citation %>
       <% end %>
       <% unless has_collection_search_parameters? %>
       <%= render 'collections/show_descriptions' %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -14,8 +14,8 @@
         <h1><%= @presenter.title %></h1>
         <p class="collection_description"><%= @presenter.description %></p>
       </header>
-      <% if !@citation.nil? %>
-      <p><b>Citation:</b> <%= @citation %>
+      <% if !@presenter.citation.nil? %>
+      <p><b>Citation:</b> <%= @presenter.citation %>
       <% end %>
       <% unless has_collection_search_parameters? %>
       <%= render 'collections/show_descriptions' %>

--- a/app/views/records/edit_fields/_citation.html.erb
+++ b/app/views/records/edit_fields/_citation.html.erb
@@ -1,0 +1,7 @@
+<% if current_user.admin? %>
+  <% if f.object.class.multiple? key %>
+    <%= f.input key, as: :multi_value_with_help, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+  <% else %>
+    <%= f.input key, required: f.object.required?(key) %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
**Stores dataset citation as metadata instead of building it from datacite api**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1353) (:star:)

# What does this Pull Request do? (:star:)
Stores dataset citation as metadata instead of building it from datacite api.

# What's the changes? (:star:)
* Removes code in Collections controller that calls datacite API and builds citation from response
* Adds citation to collection metadata using DC:bibliographicCitation
* Adds citation to collection form terms
* Adds citation to collection show terms


# How should this be tested?
* Login to VTechData with admin privileges (Citation can only be added to a dataset by admins)
* Create a Dataset, making sure to put something in the "Citation" field (at the bottom)
* Check to see that your citation renders just below the title and description (if there is one)

# Additional Notes:
* branch: `LIBTD-1353`

# Interested parties
@tingtingjh 

(:star:) Required fields
