### PR TITLE
Use filename.first for generic files in export

### DIFF
--- a/lib/vtech_data/download_generator.rb
+++ b/lib/vtech_data/download_generator.rb
@@ -71,7 +71,7 @@ class DownloadGenerator
 
     def add_files items
       items.each do |generic_file|
-        filename = !generic_file.filename.empty? ? generic_file.filename : generic_file.label
+	filename = !generic_file.filename.empty? ? generic_file.filename.first : generic_file.label
         item_target_path = File.join(archive_full_path, filename)
         # If a file already exists with this filename then put this one in a sub-directory named after the item id
         if File.file? item_target_path


### PR DESCRIPTION
**Use filename.first to create path for generic files when exporting collection.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1733) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Use filename.first to create path for generic files when exporting collection. Some files are created with an additional filename entry which causes a trailing slash to be added to the path making ruby think that it is a directory (example below)

# What's the changes? (:star:)
For some reason some generic files are created with an additional empty string value, like this:
```
irb(main):030:0> gf.filename
=> ["PC1.laz", ""]
```
When creating an export zip if the path is created using `gf.filename` then ruby will add a trailing slash after the first value because it tries to append each value in the array separated by a slash. Like this:
```
irb(main):035:0> File.join("blah", "blarg", gf.filename)
=> "blah/blarg/PC1.laz/"
```
This makes ruby think that this path refers to a directory, not a file. So we just use `gf.filename.first` instead which properly creates the path. Like this:
```
irb(main):036:0> File.join("blah", "blarg", gf.filename.first)
=> "blah/blarg/PC1.laz"
```

# How should this be tested?
* Create a collection with at least one generic file added to it.
* Open the generic file in the ruby console and check to see if it has an additional empty string value in the filename array. If it does not, then add one `your_gf.filename << ""` then `gf.save`
* Go to the collection page that this generic file belongs to and try to export it by clicking "Export Dataset" in the left column.
* Verify that the export works correctly by downloading the zip file.

# Additional Notes:
* branch: `LIBTD-1733`

# Interested parties
@tingtingjh 

(:star:) Required fields
