### PR TITLE
non-admin can't edit if any identifier present

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,11 +17,11 @@ class Ability
     # end
     ezid_shoulder = Rails.application.secrets['doi']['default_shoulder']
     cannot [:update, :destroy], ::Collection do |c|
-      c.identifier.any? {|id| id.start_with?(ezid_shoulder)}
+      !c.identifier.blank?
     end unless admin_user?
 
     cannot [:update, :destroy], ::GenericFile do |g_f|
-      g_f.collections.any? { |c| c.identifier.any? {|id| id.start_with?(ezid_shoulder)}}
+      g_f.collections.any? { |c| !c.identifier.blank? }
     end unless admin_user?
 
     can :manage, :all if admin_user?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,11 +17,11 @@ class Ability
     # end
     ezid_shoulder = Rails.application.secrets['doi']['default_shoulder']
     cannot [:update, :destroy], ::Collection do |c|
-      !c.identifier.blank?
+      c.identifier.any?
     end unless admin_user?
 
     cannot [:update, :destroy], ::GenericFile do |g_f|
-      g_f.collections.any? { |c| !c.identifier.blank? }
+      g_f.collections.any? { |c| c.identifier.any? }
     end unless admin_user?
 
     can :manage, :all if admin_user?

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -17,11 +17,11 @@ class Ability
     # end
     ezid_shoulder = Rails.application.secrets['doi']['default_shoulder']
     cannot [:update, :destroy], ::Collection do |c|
-      c.identifier.any?
+      c.identifier.any? { |identifier| !identifier.blank? }
     end unless admin_user?
 
     cannot [:update, :destroy], ::GenericFile do |g_f|
-      g_f.collections.any? { |c| c.identifier.any? }
+      g_f.collections.any? { |c| c.identifier.any? { |identifier| !identifier.blank? } }
     end unless admin_user?
 
     can :manage, :all if admin_user?


### PR DESCRIPTION
**Non-admin users should not be able to edit datasets or any items that they contain if the collection's identifier field contains any value.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1798) (:star:)

# What does this Pull Request do? (:star:)
Check for any value in a collection's identifier field to determine if collection or it's items can be edited or deleted, not just values beginning with a specific substring. With the change to datacite there will be doi's that begin with different substrings in the repository. (And only admins are allowed to edit identifiers)

# What's the changes? (:star:)
Check for any value in a collection's identifier field to determine if collection or it's items can be edited or deleted, not just values beginning with a specific substring. With the change to datacite there will be doi's that begin with different substrings in the repository. (And only admins are allowed to edit identifiers)

# How should this be tested?

* Login with admin privileges.
* Create a dataset (collection) making sure to add a value to the identifier field
* Create an item and add it to the collection
* Remove your admin privileges. I do the opposite of the process here:
https://github.com/VTUL/data-repo/blob/master/lib/tasks/datarepo.rake#L52
* Make sure that you can no longer edit or delete your dataset or it's item.

# Additional Notes:
* branch: `LIBTD-1798`

# Interested parties
@tingtingjh 

(:star:) Required fields
