### PR TITLE
switch to mailPreferredAddress

### DIFF
--- a/lib/tasks/datarepo.rake
+++ b/lib/tasks/datarepo.rake
@@ -28,7 +28,7 @@ namespace :datarepo do
 
     IO.foreach('user_list.txt') do |email|
       email = email.strip
-      filter = Net::LDAP::Filter.eq('mail', email)
+      filter = Net::LDAP::Filter.eq('mailPreferredAddress', email)
       results = ldap.search(base: treebase, filter: filter)
       if results.count == 1
         user = User.find_or_initialize_by({email: email})


### PR DESCRIPTION
**Switches user init rake task to use mailPreferredAddress instead of mail.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1775) (:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Switches user init rake task to use mailPreferredAddress instead of mail to match changes being made by central ITS

# What's the changes? (:star:)
Changes Net::LDAP::Filter to use emailPreferredAddress

# How should this be tested?
* If using a pre-existing VM open Rails console from application root by running `./bin/rails c`
* Remove any Users that might already exist in db `User.destroy_all`
* Build VM (or reprovision) with LIBTD-1775 branch with user_list.txt file present in ansible/local_files
* ssh into VM and open Rails console and check that the Users in db match what was in user_list.txt

# Additional Notes:
* branch: `LIBTD-1775`

# Interested parties
@pmather 

(:star:) Required fields
