### PR TITLE
remove ezid update stuff

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -90,26 +90,6 @@ class CollectionsController < ApplicationController
         end
       end
       @collection.update_attributes({:funder => newfunder})
-      @collection[:identifier].each do |id|
-        # Matches DOIs minted by VT Libraries
-        if /\A#{Ezid::Client.config.default_shoulder}/ =~ id
-          ezid_doi = Ezid::Identifier.find(id)
-          if ezid_doi
-            ezid_doi.update_metadata(
-              datacite_creator: (@collection.creator.empty? ? "" : @collection.creator.first),
-              datacite_title: @collection.title,
-              datacite_publisher: (@collection.publisher.empty? ? "" : @collection.publisher.first),
-              datacite_publicationyear: (@collection.date_created.empty? ? "" : @collection.date_created.first)
-            )
-          end
-          if ezid_doi.save
-            flash[:notice] = t('doi.messages.modify.success')
-          else
-            flash[:error] = t('doi.messages.modify.failure')
-          end
-          break
-        end
-      end
       after_update
     else
       after_update_error


### PR DESCRIPTION
**Removes ezid validation and metadata save from collection.update.**
* * *

**JIRA Ticket**: (https://webapps.es.vt.edu/jira/browse/LIBTD-1843) (:star:)

# What does this Pull Request do? (:star:)
Removes ezid validation and metadata save from collection.update because we aren't using ezid anymore and it's causing errors when updating.

# What's the changes? (:star:)
See above

# How should this be tested?
* Login with admin privileges
* Create a collection and save it
* Click edit on the collection
* Add a valid doi to the identifier field. You can use this one: `doi:10.7294/W4PK0DBV`
* Click "Update dataset"
* Make sure there aren't any errors during update and that the identifier field is updated

Branch: `LIBTD-1843`

@tingtingjh 