### PR TITLE
Prevent non-admin users from creating collections and items. And add notice to that effect

### DIFF
--- a/app/assets/stylesheets/global.scss
+++ b/app/assets/stylesheets/global.scss
@@ -27,3 +27,12 @@ $link-blue: #0000cc;
   padding-left: 0;
   padding-right: 0;
 }
+#transfer-notice {
+  padding: 10px;
+  font-size: 2.0rem;
+  color: white;
+  background-color: $hokie-maroon;
+  a, a:hover, a:visited {
+   color: white;
+  }
+}

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -34,7 +34,7 @@ class CollectionsController < ApplicationController
   def new
     super
     flash[:notice] = nil
-    redirect_to sufia.dashboard_index_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
+    redirect_to root_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
 
   end
 
@@ -77,6 +77,11 @@ class CollectionsController < ApplicationController
     else
       after_create_error
     end
+  end
+
+  def edit
+    super
+    redirect_to root_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
   end
 
   def update

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -34,6 +34,8 @@ class CollectionsController < ApplicationController
   def new
     super
     flash[:notice] = nil
+    redirect_to sufia.dashboard_index_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
+
   end
 
   def after_create

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,9 +1,14 @@
 class DashboardController < ApplicationController
   include Sufia::DashboardControllerBehavior
 
+  before_action :non_admin_redirect
+
   def admin_metadata_download
     Sufia.queue.push(AdminMetadataExportJob.new(request.base_url, current_user))
     redirect_to sufia.dashboard_index_path, notice: 'Your export is running in the background. You should receive an email when it is complete.'    
   end
 
+  def non_admin_redirect
+    redirect_to root_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
+  end
 end

--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -37,4 +37,9 @@ class GenericFilesController < ApplicationController
     end
   end
 
+  def new
+    super
+    redirect_to sufia.dashboard_index_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
+  end
+
 end

--- a/app/controllers/generic_files_controller.rb
+++ b/app/controllers/generic_files_controller.rb
@@ -9,6 +9,7 @@ class GenericFilesController < ApplicationController
 
   def edit
 		super
+		redirect_to root_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
 		unless current_user.admin?                                                                         
 			self.edit_form_class.terms -= [:provenance]                                                  
 			@provenance_display = "records/show_fields/provenance"
@@ -39,7 +40,7 @@ class GenericFilesController < ApplicationController
 
   def new
     super
-    redirect_to sufia.dashboard_index_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
+    redirect_to root_path, alert: "Sorry, you are not authorized to view that page" if (current_user.blank? || !current_user.admin?)
   end
 
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -16,11 +16,11 @@ class Ability
     #   can [:create], ActiveFedora::Base
     # end
     ezid_shoulder = Rails.application.secrets['doi']['default_shoulder']
-    cannot [:update, :destroy], ::Collection do |c|
+    cannot [:create, :update, :destroy], ::Collection do |c|
       c.identifier.any? { |identifier| !identifier.blank? }
     end unless admin_user?
 
-    cannot [:update, :destroy], ::GenericFile do |g_f|
+    cannot [:create, :update, :destroy], ::GenericFile do |g_f|
       g_f.collections.any? { |c| c.identifier.any? { |identifier| !identifier.blank? } }
     end unless admin_user?
 

--- a/app/views/layouts/homepage.html.erb
+++ b/app/views/layouts/homepage.html.erb
@@ -10,6 +10,7 @@
     <div id="page-positioner">
       <%= render partial: '/masthead' %>
       <div id="center-wrapper" class="col-xs-11 col-centered">
+	      <div id="transfer-notice">To publish a dataset on VTechData please contact <a href="mailto:vtechdata@vt.edu">vtechdata@vt.edu</a>. The ability to create and edit data on VTechData is restricted as we move to a new repository platform.</div>      
         <%= render partial: '/logo_title_row' %>
 
         <%= render partial: '/homepage/home_content_welcome' %>        

--- a/app/views/layouts/sufia-dashboard.html.erb
+++ b/app/views/layouts/sufia-dashboard.html.erb
@@ -8,7 +8,8 @@
       <a href="#skip_to_content" class="sr-only">Skip to Content</a>
       <%= render partial: '/masthead' %>
       <div id="center-wrapper" class="col-xs-11 col-centered">
-        <%= render partial: '/logo_title_row' %>
+      <div id="transfer-notice">To publish a dataset on VTechData please contact <a href="mailto:vtechdata@vt.edu">vtechdata@vt.edu</a>. The ability to create and edit data on VTechData is restricted as we move to a new repository platform.</div>
+	<%= render partial: '/logo_title_row' %>
 
         <div class="masthead-search-wrapper col-xs-6 col-centered">
           <%= render partial: '/catalog/search_form' %>

--- a/app/views/layouts/sufia-one-column.html.erb
+++ b/app/views/layouts/sufia-one-column.html.erb
@@ -11,7 +11,8 @@
       <a href="#skip_to_content" class="sr-only">Skip to Content</a>
       <%= render partial: '/masthead' %>
       <div id="center-wrapper" class="col-xs-11 col-centered">
-        <%= render partial: '/logo_title_row' %>
+        <div id="transfer-notice">To publish a dataset on VTechData please contact <a href="mailto:vtechdata@vt.edu">vtechdata@vt.edu</a>. The ability to create and edit data on VTechData is restricted as we move to a new repository platform.</div>
+	<%= render partial: '/logo_title_row' %>
 
         <div class="masthead-search-wrapper col-xs-6 col-centered">
           <%= render partial: '/catalog/search_form' %>


### PR DESCRIPTION
**Prevent non-admin users from creating collections and items. And add notice to that effect.**
* * *

**JIRA Ticket**: 
(https://webapps.es.vt.edu/jira/browse/LIBTD-2411)
(https://webapps.es.vt.edu/jira/browse/LIBTD-2413) 
(:star:)

* Other Relevant Links (Meeting note, project page, related pull requests, etc.)

# What does this Pull Request do? (:star:)
Prevent non-admin users from creating collections and items. And add notice to that effect

# What's the changes? (:star:)
* Remove ability for non-admins to create stuff in `models/ability.rb`
* Redirect from `GenericFiles#new` and `Collections#new` in controllers if non-admin
* Add message to let users know of this change in layout files.
* Style message to help it get noticed by users a little better.

# How should this be tested?

* Check that the new message shows up just below the header.
* Login as non-admin 
* Go to dashboard page and try to upload a file to create a GenericFile record and try to create a Collection. You should be redirected back to the dashboard page in both cases
* Login as admin
* Go to dashboard page and try to upload a file to create a GenericFile record and try to create a Collection. You should be able to do this successfully.

# Additional Notes:
* branch: `LIBTD-2413`

# Interested parties
@yinlinchen 
@pmather 

(:star:) Required fields
